### PR TITLE
Generate version file with git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ compile_commands.json
 build
 .cache
 __pycache__
+include/mist/Version.hpp

--- a/include/mist/mist.hpp
+++ b/include/mist/mist.hpp
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-#define MIST_VERSION "0.1.0"
+#include "Version.hpp"
 
 #include "Permutation.hpp"
 #include "Variable.hpp"

--- a/src/mist/CMakeLists.txt
+++ b/src/mist/CMakeLists.txt
@@ -55,9 +55,15 @@ endmacro()
 #
 # Build
 #
+# Generate version file
+add_custom_command(OUTPUT ${include_path}/Version.hpp
+    COMMAND ${PROJECT_SOURCE_DIR}/tools/make-version-file.sh ARGS ${include_path}/Version.hpp
+    DEPENDS ${PROJECT_SOURCE_DIR}/tools/make-version-file.sh
+)
 # Core Objects. These are allowed to be linked to
 add_object(Permutation Permutation.cpp ${include_path}/Permutation.hpp)
-add_object(Variable Variable.cpp ${include_path}/Variable.hpp)
+add_object(Variable Variable.cpp)
+add_object(Version Version.cpp ${include_path}/Version.hpp)
 add_object(Mist Mist.cpp ${include_path}/Mist.hpp ${include_path}/mist.hpp)
 
 # Namespaces
@@ -79,6 +85,7 @@ set(library_objects
     $<TARGET_OBJECTS:Mist>
     $<TARGET_OBJECTS:Permutation>
     $<TARGET_OBJECTS:Variable>
+    $<TARGET_OBJECTS:Version>
     ${algorithm_objects}
     ${cache_objects}
     ${io_objects}

--- a/src/mist/Version.cpp
+++ b/src/mist/Version.cpp
@@ -1,0 +1,1 @@
+#include "Version.hpp"

--- a/tools/make-version-file.sh
+++ b/tools/make-version-file.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+[[ -z "$1" ]] && exit 1
+git_tag=$(git describe --tags --abbrev=0)
+git_describe=$(git describe --tags)
+
+if [[ $git_tag =~ ^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)(-[.0-9A-Za-z-]+)?([+][.0-9A-Za-z-]+)?$ ]]; then
+	VERSION_MAJOR=${BASH_REMATCH[1]}
+	VERSION_MINOR=${BASH_REMATCH[2]}
+	VERSION_PATCH=${BASH_REMATCH[3]}
+	IDENTIFIERS=${BASH_REMATCH[4]:1}	#strip off leading '-'
+	METADATA=${BASH_REMATCH[5]:1}		#strip off leading '+'
+	if [[ $git_tag != "$git_describe" ]]; then
+		if [[ $git_describe =~ (g[0-9a-f]+)$ ]]; then
+			GIT_HASH=${BASH_REMATCH[1]}
+			METADATA=${METADATA}${GIT_HASH}
+		fi
+	fi
+	VERSION=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
+else
+	echo "Unable to get git version string, using fallback version" 1>&2
+	# Fallback hardcoded version
+	VERSION=0.1.0
+fi
+
+# Construct Semantic Version
+SEMVER=${VERSION}
+if [[ -n $IDENTIFIERS ]]; then
+	SEMVER=${SEMVER}-${IDENTIFIERS}
+fi
+if [[ -n $METADATA ]]; then
+	SEMVER=${SEMVER}+${METADATA}
+fi
+
+cat << EOF > "$1"
+#ifndef VERSION_HPP
+#define VERSION_HPP
+#define MIST_VERSION "${SEMVER}"
+#endif
+EOF


### PR DESCRIPTION
Updates:

Automatically use git tag to create version string. Non-tagged versions include git hash to help with debugging.